### PR TITLE
Migrate to openapi generator

### DIFF
--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -27,10 +27,10 @@ jobs:
         gen_dir=${output_dir}/SwaggerClient-php
 
         echo debug: download the swagger app
-        curl -o swagger-codegen-cli.jar https://repo1.maven.org/maven2/io/swagger/codegen/v3/swagger-codegen-cli/3.0.34/swagger-codegen-cli-3.0.34.jar
+        curl -o openapi-generator-cli.jar https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/6.0.1/openapi-generator-cli-6.0.1.jar
 
         echo debug: build the client to ${output_dir}
-        java  -jar swagger-codegen-cli.jar generate \
+        java  -jar openapi-generator-cli.jar generate \
               -i ${{ env.SWAGGER_URL }} \
               -l php \
               --git-user-id withreach \

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -32,7 +32,7 @@ jobs:
         echo debug: build the client to ${output_dir}
         java  -jar openapi-generator-cli.jar generate \
               -i ${{ env.SWAGGER_URL }} \
-              -l php \
+              -g php \
               --git-user-id withreach \
               --git-repo-id reach-client-php \
               -o ${output_dir}


### PR DESCRIPTION
Migrates to the community fork of the swagger codegen project to allow us to use guzzle versions >=7