### PR TITLE
[WOO-129] Missing Payment fields from session responses

### DIFF
--- a/.github/workflows/assets/swagger.yaml
+++ b/.github/workflows/assets/swagger.yaml
@@ -2232,6 +2232,14 @@ components:
           maxLength: 36
         Meta:
           $ref: '#/components/schemas/Meta'
+        PaymentDate:
+          description: "Date of /payment call against the session. Only present for completed sessions."
+          type: string
+          readOnly: true
+        PaymentMethod:
+          description: "Method used as part of a /payment call against the session. Only present for completed sessions."
+          type: string
+          readOnly: true
       required:
         - MerchantReference
         - Currency


### PR DESCRIPTION
The `PaymentMethod` and `PaymentDate` fields were missing from the Session OpenApi docs. This is useful for WOO-129, where we are attempting to get non-existing payment method data from the Order. I'll add it to the public docs in another PR.